### PR TITLE
修复"/load/resource"controller中文档加载错误

### DIFF
--- a/src/main/java/com/study/langchain4jspringboot/controller/document/DocumentController.java
+++ b/src/main/java/com/study/langchain4jspringboot/controller/document/DocumentController.java
@@ -75,7 +75,7 @@ public class DocumentController {
     @PostMapping("/load/resource")
     @Deprecated
     public String resourceDocumentEmbeddingAndStore() {
-        List<Document> documentList = ClassPathDocumentLoader.loadDocuments("documents/*.txt", documentParser);
+        List<Document> documentList = ClassPathDocumentLoader.loadDocuments("documents", documentParser);
         List<String> ids = embeddingAndStore(documentList);
         return StrUtil.format("将{}个文档，切分为：{}个段存入向量库", documentList.size(), ids.size());
     }


### PR DESCRIPTION
这个`loadDocuments`方法会尝试将路径转为url，且不支持通配符
```java
List<Document> documentList = ClassPathDocumentLoader.loadDocuments("documents/*.txt", documentParser);
```
请求/load/resource后会爆出错误：
```bash
java.lang.IllegalArgumentException: 'documents/*.txt' was not found as a classpath resource
```
修改为
```java
List<Document> documentList = ClassPathDocumentLoader.loadDocuments("documents", documentParser);
```
后可以解决